### PR TITLE
export PYTHONPATH before inference

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -38,10 +38,12 @@
 
 - 步骤4: 激活`geneface`的Python环境，然后执行: 
 ```bash
+export PYTHONPATH=./
 python inference/genefacepp_infer.py --a2m_ckpt=checkpoints/audio2motion_vae --head_ckpt= --torso_ckpt=checkpoints/motion2video_nerf/may_torso --drv_aud=data/raw/val_wavs/MacronSpeech.wav --out_name=may_demo.mp4
 ```
   - 或者可以使用我们提供的Gradio WebUI: 
 ```bash
+export PYTHONPATH=./
 python inference/app_genefacepp.py --a2m_ckpt=checkpoints/audio2motion_vae --head_ckpt= --torso_ckpt=checkpoints/motion2video_nerf/may_torso
 ```
 ## 在自己的视频上训练GeneFace++

--- a/README.md
+++ b/README.md
@@ -36,10 +36,12 @@ After these steps，your directories `checkpoints` and `data` should be like thi
 
 - Step 4: activate `geneface` Python environment, and execute: 
 ```bash
+export PYTHONPATH=./
 python inference/genefacepp_infer.py --a2m_ckpt=checkpoints/audio2motion_vae --head_ckpt= --torso_ckpt=checkpoints/motion2video_nerf/may_torso --drv_aud=data/raw/val_wavs/MacronSpeech.wav --out_name=may_demo.mp4
 ```
 Or you can play with our Gradio WebUI: 
 ```bash
+export PYTHONPATH=./
 python inference/app_genefacepp.py --a2m_ckpt=checkpoints/audio2motion_vae --head_ckpt= --torso_ckpt=checkpoints/motion2video_nerf/may_torso
 ```
 


### PR DESCRIPTION
You need to export PYTHONPATH before you can successfully run the inference script (when located in the project root directory)