### PR TITLE
Update requirements.txt set dlib version to 19.24.2

### DIFF
--- a/docs/prepare_env/requirements.txt
+++ b/docs/prepare_env/requirements.txt
@@ -60,7 +60,7 @@ s3prl
 fire
 
 # cal LMD
-dlib
+dlib==19.24.2
 
 # debug
 ipykernel


### PR DESCRIPTION
Update requirements.txt
Set the dlib version to 19.24.2, because the dlib newest 19.24.4 version was released in 04/04/2024, there have an error message with cmake, but there pip install has been installed the cmake, so need set dlib to previous version,